### PR TITLE
Add execution of subcommands

### DIFF
--- a/src/bin/brasse/main.rs
+++ b/src/bin/brasse/main.rs
@@ -2,6 +2,8 @@ use brasse::casks::get_casks;
 use brasse::formulae::get_formulae;
 use brasse::util::output::print_list;
 use clap::{command, Parser, Subcommand};
+use std::ffi::OsString;
+use std::process::{exit, Command};
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -18,6 +20,10 @@ enum Commands {
         #[arg(short = '1', long)]
         oneline: bool,
     },
+
+    /// Run an unimplemented subcommand with `brew`.
+    #[command(external_subcommand)]
+    External(Vec<OsString>),
 }
 
 fn main() {
@@ -27,6 +33,14 @@ fn main() {
         Commands::List { oneline } => {
             print_list(get_formulae().unwrap(), oneline, Some("Formulae"));
             print_list(get_casks().unwrap(), oneline, Some("Casks"));
+        }
+        Commands::External(args) => {
+            let status = Command::new("brew")
+                .args(args)
+                .status()
+                .expect("Failed to execute subcommand");
+
+            exit(status.code().unwrap_or(1));
         }
     };
 }


### PR DESCRIPTION
This allows brasse to run commands that aren't implemented yet. Those will be passed down to `brew`.
